### PR TITLE
Improve photo rendering to make it work on Logseq without plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Local Telegram Bot
 
-This is a local Telegram bot that can handle messages from and share notes with specific Telegram users. It's designed to be used as another way to use Logseq from mobile, when existing sync feature is not available yet for non-iCloud users.
+This is a local Telegram bot plugin that can handle messages from and share notes with eligible Telegram users. It's designed to be used as another way to use Logseq from mobile, when existing sync feature is not available yet for non-iCloud users.
 
 Currently, it's still under heavy development.
 

--- a/index.ts
+++ b/index.ts
@@ -496,6 +496,15 @@ function setupTimedJob(bot: Telegraf<Context>) {
   }
 }
 
+function setupMarked(bot: Telegraf<Context>) {
+  const renderer = new marked.Renderer();
+  renderer.image = (href, title, text) => {
+    return `<a href="${href}">${title ? title : "&#8288;"}</a>`;
+  };
+
+  marked.use({ renderer });
+}
+
 // FIXME: start order should be refactored to remove global bot
 // global bot
 let bot: Telegraf<Context>;
@@ -519,6 +528,8 @@ async function start() {
 
     // job at certain time
     setupTimedJob(bot);
+
+    // setupMarked(bot);
 
     if (settings.isMainBot) {
       bot.launch();

--- a/index.ts
+++ b/index.ts
@@ -441,6 +441,7 @@ function setupMacro(bot: Telegraf<Context>) {
 
     // replace the whole block with new renderer and img
     // renderer runs once at one time, so no loop
+    // invalid renderer removes itself from rendering
     // photo url from Telegram is not permanent, need to fetch everytime
     logseq.Editor.updateBlock(payload.uuid, `{{renderer :local_telegram_bot,${caption},${photoId}}}![${caption}](${photoUrl})`);
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logseq-local-telegram-bot",
-  "version": "0.0.8",
-  "description": "A local Telegram bot that can handle messages from and share notes with specific Telegram users",
+  "version": "0.0.9",
+  "description": "A local Telegram bot plugin that can handle messages from and share notes with eligible Telegram users",
   "author": "LelouchHe",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Previously, the photo received from Telegram is inserted to Logseq as customized renderer, like `{{renderer :logseq_telegram_bot,caption,photo_id}}`, simply because

1. Telegram photo url is not permanent, and it has been refreshed in some time from photo id
2. Logseq doesn't allow plugin to download photo to local storage, since it's against CORS rule

Then the plugin just parse this renderer and generate dynamically the image.

It works well on desktop app with this plugin, but looks bad on mobile platform, since it doesn't support plugin yet.

So to walkaround this issue, in this pr, the photo is inserted into  Logseq as a combination of renderer and image, like `{{renderer :logseq_telegram_bot,caption,photo_id}}![caption](photo_url)`, which means:

1. on desktop app with this plugin, it will parse the renderer and update photo url if possible, to always keep url the latest. It could also render the image in the normal way
2. on desktop with no plugin, or on mobile platform, this "invalid" renderer just doesn't render and hide itself. User will always see the image at the end of block. Since there is a desktop running the plugin to update the photo url, the latest one will always be there to sync on mobile or other platforms.

in this way, all platform can see the same thing, with a little hack

NOTE: for now, since it replaces the whole block, DON'T add new content to the same photo block. It will be addressed soon. But only after I could verify this works on mobile

